### PR TITLE
DAC6-630 - Aattributes missing from name

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -982,8 +982,8 @@ reporterIndividualName.heading = What is your full name?
 reporterIndividualName.firstName = First Name
 reporterIndividualName.secondName = Last Name
 reporterIndividualName.checkYourAnswersLabel = Reporter’s name
-reporterIndividualName.error.firstName.required = Provide a first name
-reporterIndividualName.error.secondName.required = Provide a last name
+reporterIndividualName.error.firstName.required = Enter your first name
+reporterIndividualName.error.secondName.required = Enter your last name
 reporterIndividualName.error.firstName.length = First name  must be 200 characters or less
 reporterIndividualName.error.secondName.length = Last name must be 200 characters or less
 

--- a/conf/views/individual/individualName.njk
+++ b/conf/views/individual/individualName.njk
@@ -41,6 +41,8 @@
             },
             id: "firstName",
             name: "firstName",
+            autocomplete: "given-name",
+            spellcheck: false,
             value: form.firstName.value,
             errorMessage: form.firstName.error,
             classes: "govuk-!-width-three-quarters"
@@ -52,6 +54,8 @@
               },
               id: "lastName",
               name: "secondName",
+              autocomplete: "family-name",
+              spellcheck: false,
               value: form.secondName.value,
               errorMessage: form.secondName.error,
               classes: "govuk-!-width-three-quarters"

--- a/conf/views/reporter/individual/reporterIndividualName.njk
+++ b/conf/views/reporter/individual/reporterIndividualName.njk
@@ -42,6 +42,8 @@
             classes: "govuk-!-width-two-thirds",
             id: "firstName",
             name: "firstName",
+            autocomplete: "given-name",
+            spellcheck: false,
             value: form.firstName.value,
             errorMessage: form.firstName.error
           }) }}
@@ -53,6 +55,8 @@
             classes: "govuk-!-width-two-thirds",
             id: "secondName",
             name: "secondName",
+            autocomplete: "family-name",
+            spellcheck: false,
             value: form.secondName.value,
             errorMessage: form.secondName.error
           }) }}


### PR DESCRIPTION
- add autocomplete="given-name" to the first name field
- add autocomplete="family-name" to the last name field
- add spellcheck="false" to both fields
- use “Enter your first name” and “Enter your last name” as error messages, rather than “Provide a …”